### PR TITLE
feat!: Static interop and stream serialization

### DIFF
--- a/example/lib/example.worker.vm.dart
+++ b/example/lib/example.worker.vm.dart
@@ -15,7 +15,7 @@ Future<void> _run(SendPorts ports) async {
     channel.sink.cast(),
   );
 // ignore: invalid_use_of_protected_member
-  worker.logger.info('Finished');
+  worker.logger.finest('Finished');
   unawaited(worker.close());
   Isolate.exit(ports.donePort, result);
 }

--- a/packages/e2e_test/lib/e2e_message.dart
+++ b/packages/e2e_test/lib/e2e_message.dart
@@ -3,6 +3,7 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:fixnum/fixnum.dart';
+import 'package:meta/meta.dart';
 
 part 'e2e_message.g.dart';
 
@@ -37,13 +38,13 @@ abstract class E2EMessage implements Built<E2EMessage, E2EMessageBuilder> {
   String get string;
   Uri get uri;
 
-  // @protected
-  // Stream<Object?> get intStreamUncast;
-  // Stream<int> get intStream => intStreamUncast.cast();
+  @protected
+  Stream<Object?>? get intStreamUncast;
+  Stream<int>? get intStream => intStreamUncast?.cast();
 
-  // @protected
-  // Stream<Object?> get customTypeStreamUncast;
-  // Stream<CustomType> get customTypeStream => customTypeStreamUncast.cast();
+  @protected
+  Stream<Object?>? get customTypeStreamUncast;
+  Stream<CustomType>? get customTypeStream => customTypeStreamUncast?.cast();
 
   static Serializer<E2EMessage> get serializer => _$e2EMessageSerializer;
 }
@@ -73,32 +74,41 @@ final customTypeStreamElements = [
   CustomType((b) => b..customField = 'e'),
 ];
 
-E2EMessage get message => E2EMessage((b) => b
-      ..bigInt = BigInt.from(123)
-      ..bool_ = true
-      ..builtList.add('abc')
-      ..builtListMultimap.addValues('a', ['1', '2', '3'])
-      ..builtMap.addAll({'a': '1', 'b': '2', 'c': '3'})
-      ..builtSet.add('abc')
-      ..builtSetMultimap.addValues('a', ['1', '2', '3'])
-      ..dateTime = DateTime.utc(1990, 1, 1)
-      ..double_ = 123.0
-      ..duration = Duration(minutes: 4)
-      ..int_ = 123
-      ..int64 = Int64(123)
-      ..jsonObject = JsonObject(123)
-      ..num_ = 123
-      ..regExp = RegExp(r'^\w{3}$')
-      ..string = 'abc'
-      ..uri = Uri.parse('https://example.com')
-    // ..intStreamUncast = Stream.multi(
-    //   (controller) => controller.addStream(
-    //     Stream.fromIterable(intStreamElements),
-    //   ),
-    // )
-    // ..customTypeStreamUncast = Stream.multi(
-    //   (controller) => controller.addStream(
-    //     Stream.fromIterable(customTypeStreamElements),
-    //   ),
-    // ),
+E2EMessage get message => E2EMessage(
+      (b) => b
+        ..bigInt = BigInt.from(123)
+        ..bool_ = true
+        ..builtList.add('abc')
+        ..builtListMultimap.addValues('a', ['1', '2', '3'])
+        ..builtMap.addAll({'a': '1', 'b': '2', 'c': '3'})
+        ..builtSet.add('abc')
+        ..builtSetMultimap.addValues('a', ['1', '2', '3'])
+        ..dateTime = DateTime.utc(1990, 1, 1)
+        ..double_ = 123.0
+        ..duration = Duration(minutes: 4)
+        ..int_ = 123
+        ..int64 = Int64(123)
+        ..jsonObject = JsonObject(123)
+        ..num_ = 123
+        ..regExp = RegExp(r'^\w{3}$')
+        ..string = 'abc'
+        ..uri = Uri.parse('https://example.com')
+        ..intStreamUncast = Stream.multi(
+          (controller) async {
+            await controller.addStream(
+              Stream.fromIterable(intStreamElements),
+            );
+            controller.close();
+          },
+          isBroadcast: true,
+        )
+        ..customTypeStreamUncast = Stream.multi(
+          (controller) async {
+            await controller.addStream(
+              Stream.fromIterable(customTypeStreamElements),
+            );
+            controller.close();
+          },
+          isBroadcast: true,
+        ),
     );

--- a/packages/e2e_test/lib/e2e_message.g.dart
+++ b/packages/e2e_test/lib/e2e_message.g.dart
@@ -135,7 +135,23 @@ class _$E2EMessageSerializer implements StructuredSerializer<E2EMessage> {
       'uri',
       serializers.serialize(object.uri, specifiedType: const FullType(Uri)),
     ];
-
+    Object? value;
+    value = object.intStreamUncast;
+    if (value != null) {
+      result
+        ..add('intStreamUncast')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                Stream, const [const FullType.nullable(Object)])));
+    }
+    value = object.customTypeStreamUncast;
+    if (value != null) {
+      result
+        ..add('customTypeStreamUncast')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(
+                Stream, const [const FullType.nullable(Object)])));
+    }
     return result;
   }
 
@@ -224,6 +240,18 @@ class _$E2EMessageSerializer implements StructuredSerializer<E2EMessage> {
         case 'uri':
           result.uri = serializers.deserialize(value,
               specifiedType: const FullType(Uri))! as Uri;
+          break;
+        case 'intStreamUncast':
+          result.intStreamUncast = serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      Stream, const [const FullType.nullable(Object)]))
+              as Stream<Object?>?;
+          break;
+        case 'customTypeStreamUncast':
+          result.customTypeStreamUncast = serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      Stream, const [const FullType.nullable(Object)]))
+              as Stream<Object?>?;
           break;
       }
     }
@@ -387,6 +415,10 @@ class _$E2EMessage extends E2EMessage {
   final String string;
   @override
   final Uri uri;
+  @override
+  final Stream<Object?>? intStreamUncast;
+  @override
+  final Stream<Object?>? customTypeStreamUncast;
 
   factory _$E2EMessage([void Function(E2EMessageBuilder)? updates]) =>
       (new E2EMessageBuilder()..update(updates))._build();
@@ -408,7 +440,9 @@ class _$E2EMessage extends E2EMessage {
       required this.num_,
       required this.regExp,
       required this.string,
-      required this.uri})
+      required this.uri,
+      this.intStreamUncast,
+      this.customTypeStreamUncast})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(bigInt, 'E2EMessage', 'bigInt');
     BuiltValueNullFieldError.checkNotNull(bool_, 'E2EMessage', 'bool_');
@@ -459,7 +493,9 @@ class _$E2EMessage extends E2EMessage {
         num_ == other.num_ &&
         regExp == other.regExp &&
         string == other.string &&
-        uri == other.uri;
+        uri == other.uri &&
+        intStreamUncast == other.intStreamUncast &&
+        customTypeStreamUncast == other.customTypeStreamUncast;
   }
 
   @override
@@ -481,28 +517,34 @@ class _$E2EMessage extends E2EMessage {
                                                             $jc(
                                                                 $jc(
                                                                     $jc(
-                                                                        0,
-                                                                        bigInt
+                                                                        $jc(
+                                                                            $jc(
+                                                                                0,
+                                                                                bigInt
+                                                                                    .hashCode),
+                                                                            bool_
+                                                                                .hashCode),
+                                                                        builtList
                                                                             .hashCode),
-                                                                    bool_
+                                                                    builtListMultimap
                                                                         .hashCode),
-                                                                builtList
+                                                                builtMap
                                                                     .hashCode),
-                                                            builtListMultimap
-                                                                .hashCode),
-                                                        builtMap.hashCode),
-                                                    builtSet.hashCode),
-                                                builtSetMultimap.hashCode),
-                                            dateTime.hashCode),
-                                        double_.hashCode),
-                                    duration.hashCode),
-                                int_.hashCode),
-                            int64.hashCode),
-                        jsonObject.hashCode),
-                    num_.hashCode),
-                regExp.hashCode),
-            string.hashCode),
-        uri.hashCode));
+                                                            builtSet.hashCode),
+                                                        builtSetMultimap
+                                                            .hashCode),
+                                                    dateTime.hashCode),
+                                                double_.hashCode),
+                                            duration.hashCode),
+                                        int_.hashCode),
+                                    int64.hashCode),
+                                jsonObject.hashCode),
+                            num_.hashCode),
+                        regExp.hashCode),
+                    string.hashCode),
+                uri.hashCode),
+            intStreamUncast.hashCode),
+        customTypeStreamUncast.hashCode));
   }
 
   @override
@@ -524,7 +566,9 @@ class _$E2EMessage extends E2EMessage {
           ..add('num_', num_)
           ..add('regExp', regExp)
           ..add('string', string)
-          ..add('uri', uri))
+          ..add('uri', uri)
+          ..add('intStreamUncast', intStreamUncast)
+          ..add('customTypeStreamUncast', customTypeStreamUncast))
         .toString();
   }
 }
@@ -610,6 +654,16 @@ class E2EMessageBuilder implements Builder<E2EMessage, E2EMessageBuilder> {
   Uri? get uri => _$this._uri;
   set uri(Uri? uri) => _$this._uri = uri;
 
+  Stream<Object?>? _intStreamUncast;
+  Stream<Object?>? get intStreamUncast => _$this._intStreamUncast;
+  set intStreamUncast(Stream<Object?>? intStreamUncast) =>
+      _$this._intStreamUncast = intStreamUncast;
+
+  Stream<Object?>? _customTypeStreamUncast;
+  Stream<Object?>? get customTypeStreamUncast => _$this._customTypeStreamUncast;
+  set customTypeStreamUncast(Stream<Object?>? customTypeStreamUncast) =>
+      _$this._customTypeStreamUncast = customTypeStreamUncast;
+
   E2EMessageBuilder();
 
   E2EMessageBuilder get _$this {
@@ -632,6 +686,8 @@ class E2EMessageBuilder implements Builder<E2EMessage, E2EMessageBuilder> {
       _regExp = $v.regExp;
       _string = $v.string;
       _uri = $v.uri;
+      _intStreamUncast = $v.intStreamUncast;
+      _customTypeStreamUncast = $v.customTypeStreamUncast;
       _$v = null;
     }
     return this;
@@ -682,7 +738,9 @@ class E2EMessageBuilder implements Builder<E2EMessage, E2EMessageBuilder> {
               regExp: BuiltValueNullFieldError.checkNotNull(
                   regExp, 'E2EMessage', 'regExp'),
               string: BuiltValueNullFieldError.checkNotNull(string, 'E2EMessage', 'string'),
-              uri: BuiltValueNullFieldError.checkNotNull(uri, 'E2EMessage', 'uri'));
+              uri: BuiltValueNullFieldError.checkNotNull(uri, 'E2EMessage', 'uri'),
+              intStreamUncast: intStreamUncast,
+              customTypeStreamUncast: customTypeStreamUncast);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/e2e_test/lib/e2e_worker.dart
+++ b/packages/e2e_test/lib/e2e_worker.dart
@@ -14,12 +14,11 @@ abstract class E2EWorker extends WorkerBeeBase<E2EMessage, E2EResult> {
     Stream<E2EMessage> listen,
     StreamSink<E2EResult> respond,
   ) async {
-    // Reflect a received message
     final event = await listen.first;
     final result = E2EResult((b) => b.message.replace(event));
     respond.add(result);
 
     // Complete with a result
-    return result;
+    return E2EResult((b) => b.message.replace(message));
   }
 }

--- a/packages/e2e_test/lib/e2e_worker.worker.vm.dart
+++ b/packages/e2e_test/lib/e2e_worker.worker.vm.dart
@@ -15,7 +15,7 @@ Future<void> _run(SendPorts ports) async {
     channel.sink.cast(),
   );
 // ignore: invalid_use_of_protected_member
-  worker.logger.info('Finished');
+  worker.logger.finest('Finished');
   unawaited(worker.close());
   Isolate.exit(ports.donePort, result);
 }

--- a/packages/e2e_test/lib/e2e_worker_no_result.worker.vm.dart
+++ b/packages/e2e_test/lib/e2e_worker_no_result.worker.vm.dart
@@ -15,7 +15,7 @@ Future<void> _run(SendPorts ports) async {
     channel.sink.cast(),
   );
 // ignore: invalid_use_of_protected_member
-  worker.logger.info('Finished');
+  worker.logger.finest('Finished');
   unawaited(worker.close());
   Isolate.exit(ports.donePort, result);
 }

--- a/packages/e2e_test/lib/e2e_worker_null_result.worker.vm.dart
+++ b/packages/e2e_test/lib/e2e_worker_null_result.worker.vm.dart
@@ -15,7 +15,7 @@ Future<void> _run(SendPorts ports) async {
     channel.sink.cast(),
   );
 // ignore: invalid_use_of_protected_member
-  worker.logger.info('Finished');
+  worker.logger.finest('Finished');
   unawaited(worker.close());
   Isolate.exit(ports.donePort, result);
 }

--- a/packages/e2e_test/lib/e2e_worker_pool.worker.vm.dart
+++ b/packages/e2e_test/lib/e2e_worker_pool.worker.vm.dart
@@ -16,7 +16,7 @@ Future<void> _run(SendPorts ports) async {
     channel.sink.cast(),
   );
 // ignore: invalid_use_of_protected_member
-  worker.logger.info('Finished');
+  worker.logger.finest('Finished');
   unawaited(worker.close());
   Isolate.exit(ports.donePort, result);
 }

--- a/packages/e2e_test/lib/e2e_worker_throws.worker.vm.dart
+++ b/packages/e2e_test/lib/e2e_worker_throws.worker.vm.dart
@@ -15,7 +15,7 @@ Future<void> _run(SendPorts ports) async {
     channel.sink.cast(),
   );
 // ignore: invalid_use_of_protected_member
-  worker.logger.info('Finished');
+  worker.logger.finest('Finished');
   unawaited(worker.close());
   Isolate.exit(ports.donePort, result);
 }

--- a/packages/e2e_test/lib/e2e_worker_void_result.worker.vm.dart
+++ b/packages/e2e_test/lib/e2e_worker_void_result.worker.vm.dart
@@ -15,7 +15,7 @@ Future<void> _run(SendPorts ports) async {
     channel.sink.cast(),
   );
 // ignore: invalid_use_of_protected_member
-  worker.logger.info('Finished');
+  worker.logger.finest('Finished');
   unawaited(worker.close());
   Isolate.exit(ports.donePort);
 }

--- a/packages/e2e_test/test/e2e_js_test.dart
+++ b/packages/e2e_test/test/e2e_js_test.dart
@@ -118,6 +118,12 @@ void main() {
           jsEntrypoint: 'packages/e2e_test/workers.min.js',
         ),
       );
+    }, onPlatform: {
+      'safari': Skip(
+        'Nested workers are not available in Safari:\n'
+        'https://developer.mozilla.org/en-US/docs/Web/API/Worker\n'
+        'https://bugs.webkit.org/show_bug.cgi?id=22723',
+      ),
     });
   });
 }

--- a/packages/worker_bee/README.md
+++ b/packages/worker_bee/README.md
@@ -11,6 +11,9 @@ Worker bees provide an opinionated solution to these problems, allowing a single
 
 ### Caveats
 - Request and response types must be serializable via [`built_value`](https://pub.dev/packages/built_value)
+- Stream serialization is dependent on transferable `ReadableStream`s which are not currently supported in Firefox and Safari, although both have acknowledged plans to implement them:
+  - Firefox: https://github.com/mozilla/standards-positions/issues/430
+  - Safari: https://lists.webkit.org/pipermail/webkit-dev/2020-August/031350.html
 
 ## Getting Started
 

--- a/packages/worker_bee/lib/src/common.dart
+++ b/packages/worker_bee/lib/src/common.dart
@@ -200,9 +200,9 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
 
   @protected
   set stream(Stream<Response> stream) {
-    _streamController.addStream(stream, cancelOnError: true).whenComplete(() {
-      if (!_streamController.isClosed) _streamController.close();
-    });
+    _streamController
+        .addStream(stream, cancelOnError: true)
+        .whenComplete(_streamController.close);
   }
 
   /// The sink for requests.
@@ -239,7 +239,6 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
           (op) => force ? op.cancel() : op.valueOrCancellation(),
         ));
         await sink.close();
-        if (!_streamController.isClosed) _streamController.close();
       });
 
   @override

--- a/packages/worker_bee/lib/src/common.dart
+++ b/packages/worker_bee/lib/src/common.dart
@@ -7,10 +7,7 @@ import 'package:worker_bee/src/serializers/serializers.dart';
 import 'package:worker_bee/worker_bee.dart';
 
 Type _typeOf<T>() => T;
-
-/// The type of `void`.
-@internal
-final voidType = _typeOf<void>();
+final _voidType = _typeOf<void>();
 
 /// {@template worker_bee.worker_bee_common}
 /// The common (platform-agnostic) implementations for a worker bee.
@@ -43,7 +40,7 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
     final hasResponseSerializer =
         serializers.serializerForType(Response) != null;
     // Cannot check `Response != void`
-    if (_typeOf<Response>() != voidType &&
+    if (_typeOf<Response>() != _voidType &&
         // TODO: No determination can be made when Response is nullable
         _typeOf<Response>() != _typeOf<Response?>() &&
         !hasResponseSerializer) {

--- a/packages/worker_bee/lib/src/common.dart
+++ b/packages/worker_bee/lib/src/common.dart
@@ -7,7 +7,10 @@ import 'package:worker_bee/src/serializers/serializers.dart';
 import 'package:worker_bee/worker_bee.dart';
 
 Type _typeOf<T>() => T;
-final _voidType = _typeOf<void>();
+
+/// The type of `void`.
+@internal
+final voidType = _typeOf<void>();
 
 /// {@template worker_bee.worker_bee_common}
 /// The common (platform-agnostic) implementations for a worker bee.
@@ -40,7 +43,7 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
     final hasResponseSerializer =
         serializers.serializerForType(Response) != null;
     // Cannot check `Response != void`
-    if (Response != _voidType &&
+    if (_typeOf<Response>() != voidType &&
         // TODO: No determination can be made when Response is nullable
         _typeOf<Response>() != _typeOf<Response?>() &&
         !hasResponseSerializer) {
@@ -66,6 +69,15 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
         local: !isRemoteWorker,
       ));
     });
+  }
+
+  /// Operations which must complete before calling [close].
+  final List<CancelableOperation<void>> _pendingOperations = [];
+
+  /// Adds a Future to track which will be closed on [close].
+  @protected
+  void addPendingOperation(CancelableOperation<void> pendingOp) {
+    _pendingOperations.add(pendingOp);
   }
 
   /// The name of the worker.
@@ -144,10 +156,10 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
     StreamChannel<LogMessage>? logsChannel,
   }) async {
     _isRemoteWorker = true;
-    logger.info('Connected from worker');
     if (logsChannel != null) {
       _logsChannel = logsChannel;
     }
+    logger.finest('Connected from worker');
   }
 
   /// The asynchronous ready trigger.
@@ -155,7 +167,8 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
   final Completer<void> ready = Completer();
 
   final StreamSinkCompleter<Request> _sinkCompleter = StreamSinkCompleter();
-  final StreamCompleter<Response> _streamCompleter = StreamCompleter();
+  final StreamController<Response> _streamController =
+      StreamController.broadcast(sync: true);
   final Completer<Result<Response?>> _resultCompleter = Completer.sync();
 
   /// Whether the worker bee has been completed and/or is closed.
@@ -165,29 +178,31 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
   @protected
   void complete(Response? result) {
     if (isCompleted) return;
-    logger.fine('Finished with result: $result');
+    logger.finest('Finished with result: $result');
     _resultCompleter.complete(Result.value(result));
-    close();
+    close(force: false);
   }
 
   /// Internal method for completing with an error.
   @protected
   void completeError(Object error, [StackTrace? stackTrace]) {
     logger.severe('Error in worker', error, stackTrace);
-    if (isCompleted) return;
-    _resultCompleter.complete(Result.error(error, stackTrace));
-    close();
+    if (!isCompleted) {
+      _resultCompleter.complete(Result.error(error, stackTrace));
+    }
+    close(force: true);
   }
 
-  late final Stream<Response> _stream =
-      _streamCompleter.stream.asBroadcastStream();
+  late final Stream<Response> _stream = _streamController.stream;
 
   /// The stream of responses.
   Stream<Response> get stream => _stream;
 
   @protected
   set stream(Stream<Response> stream) {
-    _streamCompleter.setSourceStream(stream);
+    _streamController.addStream(stream, cancelOnError: true).whenComplete(() {
+      if (!_streamController.isClosed) _streamController.close();
+    });
   }
 
   /// The sink for requests.
@@ -211,13 +226,21 @@ abstract class WorkerBeeCommon<Request extends Object, Response>
   @override
   Future<void> addStream(Stream<Request> stream) => sink.addStream(stream);
 
+  final AsyncMemoizer<void> _closeMemoizer = AsyncMemoizer();
+
   @override
   @mustCallSuper
-  Future<void> close() async {
-    logger.info('Closing worker');
-    await sink.close();
-    await logsController.close();
-  }
+  Future<void> close({
+    bool force = false,
+  }) =>
+      _closeMemoizer.runOnce(() async {
+        logger.finest('Closing worker (force=$force)');
+        await Future.wait(_pendingOperations.map(
+          (op) => force ? op.cancel() : op.valueOrCancellation(),
+        ));
+        await sink.close();
+        if (!_streamController.isClosed) _streamController.close();
+      });
 
   @override
   Future<void> get done => sink.done;

--- a/packages/worker_bee/lib/src/js/interop/common.dart
+++ b/packages/worker_bee/lib/src/js/interop/common.dart
@@ -1,0 +1,373 @@
+// ignore_for_file: prefer_void_to_null
+
+@JS()
+@internal
+library aws_http.js.common;
+
+import 'dart:async';
+import 'dart:js_util' as js_util;
+
+import 'package:js/js.dart';
+import 'package:meta/meta.dart';
+import 'package:worker_bee/src/recase.dart';
+
+/// The JS `undefined`.
+///
+/// Marked as `dynamic` so that this can be used in place of `null` in
+/// strongly-typed APIs of type `T?`.
+@JS()
+external Null get undefined;
+
+/// An [Enum] representing a nullable JS value.
+mixin JSEnum on Enum {
+  /// The JS representation of `this`.
+  ///
+  /// Default values are represented as `undefined`, as opposed to `null` which
+  /// can be interpreted incorrectly by DOM APIs. Non-default values are
+  /// representated as the parameter-cased [name].
+  dynamic get jsValue {
+    switch (name) {
+      case r'default$':
+        return undefined;
+      default:
+        return name.paramCase;
+    }
+  }
+}
+
+/// Refers to either [window] or the worker's global scope, depending on the
+/// program's execution context.
+@JS()
+external GlobalScope get self;
+
+/// The window object of the current context.
+@JS()
+external Window? get window;
+
+/// The Window interface represents a window containing a DOM document.
+@JS()
+@staticInterop
+abstract class Window implements GlobalScope {}
+
+/// A function which handles DOM events.
+typedef EventHandler<T extends Event> = void Function(T event);
+
+/// {@template amplify_secure_storage_dart.event}
+/// The Event interface represents an event which takes place in the DOM.
+/// {@endtemplate}
+@JS()
+@staticInterop
+abstract class Event {}
+
+/// {@macro amplify_secure_storage_dart.event}
+extension PropsEvent on Event {
+  /// A reference to the object onto which this event was dispatched.
+  external EventTarget? get target;
+}
+
+/// {@template worker_bee.js.interop.event_target}
+/// The EventTarget interface is implemented by objects that can receive events
+/// and may have listeners for them.
+/// {@endtemplate}
+@JS()
+@staticInterop
+abstract class EventTarget {}
+
+/// {@macro worker_bee.js.interop.event_target}
+extension PropsEventTarget on EventTarget {
+  /// Registers [listener] as a callback for events of type [type].
+  void addEventListener<T extends Event>(
+    String type,
+    EventHandler<T> listener,
+  ) =>
+      js_util.callMethod(this, 'addEventListener', [
+        type,
+        allowInterop(listener),
+        false,
+      ]);
+
+  /// Removes [listener] as a callback for events of type [type].
+  void removeEventListener<T extends Event>(
+    String type,
+    EventHandler<T> listener,
+  ) =>
+      js_util.callMethod(this, 'removeEventListener', [
+        type,
+        allowInterop(listener),
+        false,
+      ]);
+}
+
+Object? _convertToJs(Object? o) {
+  if (o == null || o is! Map || o is! Iterable) return o;
+  return js_util.jsify(o);
+}
+
+/// {@template worker_bee.js.interop.global_scope}
+/// The global execution context, referred to by [self].
+///
+/// Either a [Window] object or a [WorkerGlobalScope] object.
+/// {@endtemplate}
+@JS()
+@staticInterop
+class GlobalScope extends EventTarget {}
+
+/// {@macro worker_bee.js.interop.global_scope}
+extension PropsGlobalScope on GlobalScope {
+  /// A [Location] object with information about the current location of the
+  /// document.
+  external Location get location;
+
+  /// When called on a [WorkerGlobalScope], this sends a message to the main
+  /// thread that spawned it.
+  ///
+  /// When called on a [Window], this sends a message to the parent window
+  /// object.
+  void postMessage(
+    Object? o, [
+    List<Object>? transfer,
+  ]) =>
+      js_util.callMethod(this, 'postMessage', [
+        _convertToJs(o),
+        transfer?.map(_convertToJs).toList(),
+      ]);
+}
+
+/// {@template worker_bee.js.interop.message_event}
+/// The MessageEvent interface represents a message received by a target object.
+/// {@endtemplate}
+@JS()
+@staticInterop
+class MessageEvent extends Event {}
+
+/// {@macro worker_bee.js.interop.message_event}
+extension PropsMessageEvent on MessageEvent {
+  /// The data sent by the message emitter.
+  Object? get data {
+    final Object? data = js_util.getProperty(this, 'data');
+    return dartify(data);
+  }
+
+  /// An array of [MessagePort] objects representing the ports associated with
+  /// the channel the message is being sent through.
+  List<MessagePort> get ports {
+    final Object ports = js_util.getProperty(this, 'ports');
+    return (dartify(ports, recursive: false) as List).cast<MessagePort>();
+  }
+}
+
+/// {@template worker_bee.js.interop.message_port}
+/// The MessagePort interface of the Channel Messaging API represents one of the
+/// two ports of a [MessageChannel], allowing messages to be sent from one port
+/// and listening out for them arriving at the other.
+/// {@endtemplate}
+@JS()
+@staticInterop
+class MessagePort extends EventTarget {}
+
+/// {@macro worker_bee.js.interop.message_port}
+extension PropsMessagePort on MessagePort {
+  /// Fired when a MessagePort object receives a message.
+  Stream<MessageEvent> get onMessage {
+    final StreamController<MessageEvent> _controller = StreamController();
+    addEventListener<MessageEvent>('message', _controller.add);
+    addEventListener<MessageEvent>('messageerror', ((event) {
+      _controller.addError(event);
+      _controller.close();
+    }));
+    scheduleMicrotask(start);
+    return _controller.stream;
+  }
+
+  /// Sends a message from the port, and optionally, transfers ownership of
+  /// objects to other browsing contexts.
+  void postMessage(
+    Object? o, [
+    List<Object>? transfer,
+  ]) =>
+      js_util.callMethod(this, 'postMessage', [
+        _convertToJs(o),
+        transfer?.map(_convertToJs).toList(),
+      ]);
+
+  /// Starts the sending of messages queued on the port.
+  ///
+  /// Only needed when using `EventTarget.addEventListener`; it is implied when
+  /// using [onMessage].
+  external void start();
+
+  /// Disconnects the port, so it is no longer active.
+  external void close();
+}
+
+/// {@template worker_bee.js.interop.location}
+/// The Location interface represents the location (URL) of the object it is
+/// linked to.
+/// {@endtemplate}
+@JS()
+@staticInterop
+abstract class Location {}
+
+/// {@macro worker_bee.js.interop.location}
+extension PropsLocation on Location {
+  /// The entire URL.
+  external String get href;
+}
+
+/// {@template worker_bee.js.interop.worker_init}
+/// An object containing option properties that can be set when creating a
+/// [Worker] instance.
+/// {@endtemplate}
+@JS()
+@anonymous
+@staticInterop
+class WorkerInit {
+  /// {@macro worker_bee.js.interop.worker_init}
+  external factory WorkerInit({
+    String? type,
+  });
+}
+
+/// {@template worker_bee.js.interop.worker}
+/// The Worker interface of the Web Workers API represents a background task
+/// that can be created via script, which can send messages back to its creator.
+/// {@endtemplate}
+@JS()
+@staticInterop
+class Worker extends EventTarget {
+  /// {@macro worker_bee.js.interop.worker}
+  external factory Worker(String url, [WorkerInit? init]);
+}
+
+/// {@macro worker_bee.js.interop.worker}
+extension PropsWorker on Worker {
+  /// The error event of the Worker interface fires when an error occurs in the
+  /// worker.
+  set onError(EventHandler listener) {
+    js_util.setProperty(this, 'onerror', allowInterop(listener));
+  }
+
+  /// The `message` event is fired on a Worker object when the worker's parent
+  /// receives a message from its worker.
+  set onMessage(EventHandler<MessageEvent> listener) {
+    js_util.setProperty(this, 'onmessage', allowInterop(listener));
+  }
+
+  /// Sends a message to the worker's inner scope.
+  external void postMessage(Object? o, [List<Object?>? transfer]);
+
+  /// Immediately terminates the Worker.
+  ///
+  /// This does not offer the worker an opportunity to finish its operations;
+  /// it is stopped at once.
+  external void terminate();
+}
+
+/// {@template worker_bee.js.interop.error_event}
+/// The ErrorEvent interface represents events providing information related to
+/// errors in scripts or in files.
+/// {@endtemplate}
+@JS()
+@staticInterop
+class ErrorEvent extends Event {}
+
+/// {@macro worker_bee.js.interop.error_event}
+extension PropsErrorEvent on ErrorEvent {
+  /// The error object associated with the event.
+  external Object? get error;
+
+  /// A string containing a human-readable error message describing the problem.
+  external String? get message;
+}
+
+/// {@template worker_bee.js.interop.message_channel}
+/// The MessageChannel interface of the Channel Messaging API allows us to
+/// create a new message channel and send data through it via its two
+/// [MessagePort] properties.
+/// {@endtemplate}
+@JS()
+@staticInterop
+class MessageChannel {
+  /// {@macro worker_bee.js.interop.message_channel}
+  external factory MessageChannel();
+}
+
+/// {@macro worker_bee.js.interop.message_channel}
+extension PropsMessageChannel on MessageChannel {
+  /// Port 1 of the channel.
+  external MessagePort get port1;
+
+  /// Port 2 of the channel.
+  external MessagePort get port2;
+}
+
+/// {@template worker_bee.js.interop.js_object}
+/// The base class for all JavaScript objects.
+/// {@endtemplate}
+@JS('Object')
+@staticInterop
+class JSObject {
+  /// Returns an array of a given [object]'s own enumerable property names,
+  /// iterated in the same order that a normal loop would.
+  external static List<String> keys(Object object);
+
+  /// Returns the prototype (i.e. the value of the internal `[[Prototype]]`
+  /// property) of the specified [object].
+  external static Object? getPrototypeOf(Object? object);
+
+  /// The prototype of the JS `Object` class.
+  external static Object get prototype;
+}
+
+/// Returns `true` if a given object is a simple JavaScript object.
+bool isJavaScriptSimpleObject(Object? value) {
+  final Object? proto = JSObject.getPrototypeOf(value);
+  return proto == null || proto == JSObject.prototype;
+}
+
+Object? _getConstructor(String constructorName) =>
+    js_util.getProperty(self, constructorName);
+
+/// Like [js_util.instanceof] only takes a [String] for the object name instead
+/// of a constructor object.
+bool instanceOfString(Object? element, String objectType) {
+  Object? constructor = _getConstructor(objectType);
+  return constructor != null && js_util.instanceof(element, constructor);
+}
+
+/// Returns `true` if a given object is a JavaScript array.
+bool isJavaScriptArray(Object? value) => instanceOfString(value, 'Array');
+
+/// Effectively the inverse of [js_util.jsify], [dartify] Takes a JavaScript
+/// object, and converts it to a Dart based object. Only JS primitives, arrays,
+/// or 'map' like JS objects are supported.
+Object? dartify(Object? o, {bool recursive = true}) {
+  if (o == null) return null;
+  if (isJavaScriptSimpleObject(o)) {
+    Map<Object?, Object?> dartObject = {};
+    List<Object?> originalKeys = JSObject.keys(o);
+    List<Object?> dartKeys = [];
+    for (Object? key in originalKeys) {
+      dartKeys.add(recursive ? dartify(key) : key);
+    }
+    for (int i = 0; i < originalKeys.length; i++) {
+      Object? jsKey = originalKeys[i];
+      Object? dartKey = dartKeys[i];
+      if (jsKey != null) {
+        final Object? jsValue = js_util.getProperty(o, jsKey);
+        dartObject[dartKey] = recursive ? dartify(jsValue) : jsValue;
+      }
+    }
+    return dartObject;
+  }
+  if (isJavaScriptArray(o)) {
+    List<Object?> dartObject = [];
+    int length = js_util.getProperty(o, 'length');
+    for (int i = 0; i < length; i++) {
+      final Object? jsValue = js_util.getProperty(o, i);
+      dartObject.add(recursive ? dartify(jsValue) : jsValue);
+    }
+    return dartObject;
+  }
+  return o;
+}

--- a/packages/worker_bee/lib/src/js/interop/promise.dart
+++ b/packages/worker_bee/lib/src/js/interop/promise.dart
@@ -1,0 +1,55 @@
+@internal
+library aws_http.js.promise;
+
+import 'dart:async';
+
+import 'package:js/js.dart';
+import 'package:js/js_util.dart' as js_util;
+import 'package:meta/meta.dart';
+
+/// A [Promise] executor callback.
+typedef Executor<T> = void Function(
+  void Function(T) resolve,
+  void Function(Object) reject,
+);
+
+/// {@template worker_bee.js.interop.promise}
+/// The Promise object represents the eventual completion (or failure) of an
+/// asynchronous operation and its resulting value.
+/// {@endtemplate}
+@JS()
+@staticInterop
+class Promise<T> {
+  /// {@macro worker_bee.js.interop.promise}
+  factory Promise(Executor<T> executor) => Promise._(allowInterop(executor));
+
+  external factory Promise._(Executor<T> executor);
+
+  /// Creates a Promise from a Dart [future].
+  ///
+  /// If [captureError] is `true`, all errors will be caught by the promise
+  /// and not reported as unhandled errors in the current [Zone]. This can
+  /// decrease the visibility of errors in Dart code depending on the level of
+  /// integration with JS APIs and their error-handling specifics.
+  factory Promise.fromFuture(
+    Future<T> future, {
+    bool captureError = false,
+  }) {
+    return Promise((resolve, reject) async {
+      try {
+        resolve(await future);
+      } on Object catch (e) {
+        reject(e);
+        if (!captureError) {
+          rethrow;
+        }
+      }
+    });
+  }
+}
+
+/// {@macro worker_bee.js.interop.promise}
+extension PropsPromise<T> on Promise<T> {
+  /// Resolves `this` as a Dart [Future].
+  Future<T> get future => js_util.promiseToFuture(this);
+}

--- a/packages/worker_bee/lib/src/js/interop/readable_stream.dart
+++ b/packages/worker_bee/lib/src/js/interop/readable_stream.dart
@@ -1,0 +1,383 @@
+@internal
+library aws_http.js.readable_stream;
+
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:js/js.dart';
+import 'package:js/js_util.dart' as js_util;
+import 'package:meta/meta.dart';
+
+import 'common.dart';
+import 'promise.dart';
+
+/// Whether the current browser supports transferring [ReadableStream].
+bool get supportsTransferableStreams {
+  final rs = ReadableStream();
+  try {
+    final MessageChannel channel = MessageChannel();
+    channel.port1.postMessage(rs, [rs]);
+    return true;
+  } on Object {
+    return false;
+  }
+}
+
+/// {@template aws_http.js.readable_stream}
+/// An object containing methods and properties that define how the constructed
+/// [ReadableStream] will behave.
+/// {@endtemplate}
+@JS()
+@staticInterop
+@anonymous
+class UnderlyingSource {
+  /// {@macro aws_http.js.readable_stream}
+  factory UnderlyingSource({
+    /// This is a method, called immediately when the object is constructed.
+    ///
+    /// The contents of this method are defined by the developer, and should aim
+    /// to get access to the stream source, and do anything else required to set
+    /// up the stream functionality. If this process is to be done
+    /// asynchronously, it can return a promise to signal success or failure.
+    ///
+    /// The `controller` parameter passed to this method is a
+    /// [ReadableStreamDefaultController] or a [ReadableByteStreamController],
+    /// depending on the value of the `type` property. This can be used by the
+    /// developer to control the stream during set up.
+    FutureOr<void> Function(ReadableStreamController controller)? start,
+
+    /// This method, also defined by the developer, will be called repeatedly
+    /// when the stream's internal queue of chunks is not full, up until it
+    /// reaches its high water mark.
+    ///
+    /// If pull() returns a promise, then it won't be called again until that
+    /// promise fulfills; if the promise rejects, the stream will become
+    /// errored.
+    ///
+    /// The `controller` parameter passed to this method is a
+    /// [ReadableStreamDefaultController] or a [ReadableByteStreamController],
+    /// depending on the value of the type property. This can be used by the
+    /// developer to control the stream as more chunks are fetched.
+    FutureOr<void> Function(ReadableStreamController controller)? pull,
+
+    /// This method, also defined by the developer, will be called if the app
+    /// signals that the stream is to be cancelled
+    /// (e.g. if [ReadableStream.cancel] is called).
+    ///
+    /// The contents should do whatever is necessary to release access to the
+    /// stream source. If this process is asynchronous, it can return a promise
+    /// to signal success or failure. The reason parameter contains a
+    /// `DOMString` describing why the stream was cancelled.
+    FutureOr<void> Function([
+      String? reason,
+      ReadableStreamController? controller,
+    ])?
+        cancel,
+
+    /// This property controls what type of readable stream is being dealt with.
+    ReadableStreamType type = ReadableStreamType.default$,
+
+    /// For byte streams, the developer can set the autoAllocateChunkSize with
+    /// a positive integer value to turn on the stream's auto-allocation
+    /// feature.
+    ///
+    /// With this turned on, the stream implementation will automatically
+    /// allocate an `ArrayBuffer` with a size of the given integer, and the
+    /// consumer can also use a default reader.
+    int? autoAllocateChunkSize,
+  }) {
+    final startFn = start == null
+        ? undefined
+        : start is Future<void> Function(ReadableStreamController)
+            ? allowInterop((ReadableStreamController controller) {
+                return Promise.fromFuture(start(controller));
+              })
+            : allowInterop(start);
+    final pullFn = pull == null
+        ? undefined
+        : pull is Future<void> Function(ReadableStreamController)
+            ? allowInterop((ReadableStreamController controller) {
+                return Promise.fromFuture(pull(controller));
+              })
+            : allowInterop(pull);
+    final cancelFn = cancel == null
+        ? undefined
+        : cancel is Future<void> Function([
+            String? reason,
+            ReadableStreamController? controller,
+          ])
+            ? allowInterop(
+                (String? reason, ReadableStreamController controller) {
+                return Promise.fromFuture(cancel(reason, controller));
+              })
+            : allowInterop(cancel);
+    return UnderlyingSource._(
+      start: startFn,
+      pull: pullFn,
+      cancel: cancelFn,
+      type: type.jsValue,
+      autoAllocateChunkSize: autoAllocateChunkSize ?? undefined,
+    );
+  }
+
+  external factory UnderlyingSource._({
+    Object? start,
+    Object? pull,
+    Object? cancel,
+    String? type,
+    int? autoAllocateChunkSize,
+  });
+}
+
+/// The type of [ReadableStream] and its associated [ReadableStreamController].
+enum ReadableStreamType with JSEnum {
+  /// Creates a [ReadableByteStreamController] capable of handling a BYOB
+  /// (bring your own buffer)/byte stream.
+  bytes,
+
+  /// Creates a [ReadableStreamDefaultController].
+  default$,
+}
+
+/// {@template worker_bee.js.interop.readable_stream_controller}
+/// A controller allowing control of a [ReadableStream]'s state and internal
+/// queue.
+/// {@endtemplate}
+@JS()
+@staticInterop
+abstract class ReadableStreamController<T> {}
+
+/// {@macro worker_bee.js.interop.readable_stream_controller}
+extension PropsReadableStreamController<T> on ReadableStreamController<T> {
+  /// The desired size required to fill the stream's internal queue.
+  external int get desiredSize;
+
+  /// Closes the associated stream.
+  external void close();
+
+  /// Enqueues a given chunk in the associated stream.
+  external void enqueue(T chunk);
+}
+
+/// {@macro worker_bee.js.interop.readable_stream_controller}
+@JS()
+@staticInterop
+class ReadableStreamDefaultController<T> extends ReadableStreamController<T> {}
+
+/// {@macro worker_bee.js.interop.readable_stream_controller}
+@JS()
+@staticInterop
+class ReadableByteStreamController<T> extends ReadableStreamController<T> {}
+
+/// {@template worker_bee.js.interop.readable_stream}
+/// A readable stream of data.
+/// {@endtemplate}
+@JS()
+@staticInterop
+class ReadableStream<T extends Object?> {
+  /// {@macro worker_bee.js.interop.readable_stream}
+  external factory ReadableStream([UnderlyingSource? underlyingSource]);
+}
+
+/// Used to expand [ReadableStream] and treat [ReadableStream.stream] as a
+/// `late final` property so that multiple accesses return the same value.
+final Expando<ReadableStreamView> _readableStreamViews =
+    Expando('ReadableStreamViews');
+
+/// {@macro worker_bee.js.interop.readable_stream}
+extension PropsReadableStream<T extends Object?> on ReadableStream<T> {
+  /// Whether or not the readable stream is locked to a reader.
+  external bool get locked;
+
+  /// Returns a Promise that resolves when the stream is canceled.
+  ///
+  /// Calling this method signals a loss of interest in the stream by a
+  /// consumer. The supplied reason argument will be given to the underlying
+  /// source, which may or may not use it.
+  Future<void> cancel([String? reason]) =>
+      js_util.promiseToFuture(js_util.callMethod(this, 'cancel', [reason]));
+
+  /// Creates a reader and locks the stream to it.
+  ///
+  /// While the stream is locked, no other reader can be acquired until this one
+  /// is released.
+  ReadableStreamReader getReader({
+    ReadableStreamReaderMode mode = ReadableStreamReaderMode.default$,
+  }) =>
+      js_util.callMethod(this, 'getReader', [mode.jsValue]);
+
+  /// Creates a Dart [Stream] from `this`.
+  Stream<T> get stream =>
+      (_readableStreamViews[this] ??= ReadableStreamView<T>(this)) as Stream<T>;
+
+  /// The progress (in bytes) of [stream].
+  Stream<int> get progress => (stream as ReadableStreamView).progress;
+}
+
+/// {@template worker_bee.js.interop.readable_stream_reader}
+/// An object used to read stream data which holds a lock on the stream while
+/// it reads.
+/// {@endtemplate}
+@JS()
+@staticInterop
+abstract class ReadableStreamReader {}
+
+/// {@macro worker_bee.js.interop.readable_stream_reader}
+extension PropsReadableStreamReader on ReadableStreamReader {
+  /// Returns a Promise that fulfills when the stream closes, or rejects if the
+  /// stream throws an error or the reader's lock is released.
+  ///
+  /// This property enables you to write code that responds to an end to the
+  /// streaming process.
+  Future<void> get closed =>
+      js_util.promiseToFuture(js_util.getProperty(this, 'closed'));
+
+  /// Returns a Promise that resolves when the stream is canceled.
+  ///
+  /// Calling this method signals a loss of interest in the stream by a
+  /// consumer. The supplied reason argument will be given to the underlying
+  /// source, which may or may not use it.
+  Future<void> cancel([String? reason]) =>
+      js_util.promiseToFuture(js_util.callMethod(this, 'cancel', [reason]));
+
+  /// Releases the reader's lock on the stream.
+  external void releaseLock();
+}
+
+/// {@macro worker_bee.js.interop.readable_stream_reader}
+@JS()
+@staticInterop
+class ReadableStreamBYOBReader extends ReadableStreamReader {}
+
+/// {@macro worker_bee.js.interop.readable_stream_reader}
+@JS()
+@staticInterop
+class ReadableStreamDefaultReader extends ReadableStreamReader {}
+
+/// {@macro worker_bee.js.interop.readable_stream_reader}
+extension PropsReadableStreamDefaultReader on ReadableStreamDefaultReader {
+  /// Returns a promise providing access to the next chunk in the stream's
+  /// internal queue.
+  Future<ReadableStreamChunk<T>> read<T extends Object?>() =>
+      js_util.promiseToFuture(js_util.callMethod(this, 'read', []));
+}
+
+/// Specifies the type of [ReadableStreamReader] to create.
+enum ReadableStreamReaderMode with JSEnum {
+  /// Results in a [ReadableStreamBYOBReader] being created that can read
+  /// readable byte streams (i.e. can handle "bring your own buffer" reading).
+  byob,
+
+  /// Results in a [ReadableStreamDefaultReader] being created that can read
+  /// individual chunks from a stream.
+  default$
+}
+
+/// {@template worker_bee.js.interop.readable_stream_chunk}
+/// A chunk delivered to a [ReadableStream].
+/// {@endtemplate}
+@JS()
+@staticInterop
+@anonymous
+abstract class ReadableStreamChunk<T extends Object?> {}
+
+/// {@macro worker_bee.js.interop.readable_stream_chunk}
+extension PropsReadableStreamChunk<T extends Object?>
+    on ReadableStreamChunk<T> {
+  /// The chunk of data.
+  ///
+  /// Always `null` when [done] is `true`.
+  external T? get value;
+
+  /// Whether the stream is done producing values.
+  external bool get done;
+}
+
+/// {@template aws_http.js.readable_stream_view}
+/// Wraps a [ReadableStream] as a Dart [Stream].
+/// {@endtemplate}
+class ReadableStreamView<T extends Object?> extends StreamView<T> {
+  /// {@macro aws_http.js.readable_stream_view}
+  factory ReadableStreamView(ReadableStream<T> stream) {
+    // Closed in `_pipe`.
+    // ignore: close_sinks
+    final controller = StreamController<T>(sync: true);
+    // ignore: close_sinks
+    final progressController = StreamController<int>.broadcast(sync: true);
+    _pipeFrom(stream, controller.sink, progressController.sink);
+    return ReadableStreamView._(
+      controller.stream,
+      progressController.stream,
+    );
+  }
+
+  const ReadableStreamView._(super.stream, this.progress);
+
+  /// The number of bytes read so far.
+  ///
+  /// Closes when `this` closes.
+  final Stream<int> progress;
+
+  static Future<void> _pipeFrom<T extends Object?>(
+    ReadableStream stream,
+    StreamSink<T> sink,
+    StreamSink<int> progressSink,
+  ) async {
+    try {
+      final reader = stream.getReader() as ReadableStreamDefaultReader;
+      var bytesRead = 0;
+      while (true) {
+        final chunk = await reader.read<T>();
+        final value = chunk.value;
+        if (chunk.done || value is! T) {
+          break;
+        }
+        if (value is List<int>) {
+          bytesRead += value.length;
+          progressSink.add(bytesRead);
+        }
+        sink.add(value);
+      }
+    } on Object catch (e, st) {
+      sink.addError(e, st);
+    } finally {
+      sink.close();
+      progressSink.close();
+    }
+  }
+}
+
+/// {@template aws_http.js.stream_to_readable_stream}
+/// Creates a [ReadableStream] from `this`.
+/// {@endtemplate}
+extension StreamToReadableStream<T> on Stream<T> {
+  /// {@macro aws_http.js.stream_to_readable_stream}
+  ReadableStream asReadableStream({
+    void Function(Object, StackTrace)? onError,
+  }) {
+    final queue = StreamQueue(this);
+    return ReadableStream(
+      UnderlyingSource(
+        pull: (controller) async {
+          try {
+            if (!await queue.hasNext) {
+              await queue.cancel();
+              controller.close();
+              return;
+            }
+            final chunk = await queue.next;
+            controller.enqueue(chunk);
+          } on Object catch (e, st) {
+            await queue.cancel();
+            // Allow error to propogate before closing.
+            scheduleMicrotask(controller.close);
+            if (onError == null) {
+              rethrow;
+            }
+            onError.call(e, st);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/packages/worker_bee/lib/src/js/preamble.dart
+++ b/packages/worker_bee/lib/src/js/preamble.dart
@@ -1,43 +1,25 @@
 @JS()
 
 import 'dart:async';
-import 'dart:html';
 
 import 'package:built_value/serializer.dart';
 import 'package:collection/collection.dart';
 import 'package:js/js.dart';
+import 'package:worker_bee/src/js/interop/common.dart';
 import 'package:worker_bee/src/preamble.dart';
 import 'package:worker_bee/src/serializers/serializers.dart';
 import 'package:worker_bee/worker_bee.dart';
 
 import 'message_port_channel.dart';
-import 'util.dart';
-
-@JS('window')
-external WindowBase? get _window;
-
-// Use staticInterop here because the `href` getter throws when using built-in
-// dart2js getter.
-
-@JS()
-@staticInterop
-class _JsWorkerLocation {}
-
-extension on _JsWorkerLocation {
-  external String get href;
-}
 
 /// {@macro worker_bee.is_web_worker}
 bool get isWebWorker {
-  return _window == null;
+  return window == null;
 }
 
 /// {@macro worker_bee.current_uri}
 Uri get currentUri {
-  return (isWebWorker
-          ? Uri.tryParse((self.location as _JsWorkerLocation).href)
-          : Uri.tryParse(window.location.href)) ??
-      Uri();
+  return Uri.tryParse(self.location.href) ?? Uri();
 }
 
 /// {@macro worker_bee.get_worker_assignment}

--- a/packages/worker_bee/lib/src/js/util.dart
+++ b/packages/worker_bee/lib/src/js/util.dart
@@ -1,11 +1,6 @@
 @JS()
 
-import 'dart:html';
-
 import 'package:js/js.dart';
-
-/// The context-independent global scope.
-final self = DedicatedWorkerGlobalScope.instance;
 
 /// Browser-based JSON utilities.
 @JS()

--- a/packages/worker_bee/lib/src/pool/worker_pool.dart
+++ b/packages/worker_bee/lib/src/pool/worker_pool.dart
@@ -51,9 +51,11 @@ abstract class WorkerPoolBase<Request extends Object, Response,
   }
 
   @override
-  Future close() async {
-    await super.close();
+  Future<void> close({
+    bool force = false,
+  }) async {
     await _pool?.close();
+    await super.close(force: force);
   }
 }
 
@@ -114,9 +116,9 @@ class WorkerPool<Request extends Object, Response,
   Future<void> close() async {
     await Future.wait<void>([
       for (final worker in pool)
-        if (worker.hasRun) (await worker.future).close(),
+        if (worker.hasRun) worker.future.then((worker) => worker.close()),
     ]);
-    await _logsController.close();
     await sink.close();
+    await _logsController.close();
   }
 }

--- a/packages/worker_bee/lib/src/recase.dart
+++ b/packages/worker_bee/lib/src/recase.dart
@@ -1,0 +1,179 @@
+// Extended from recase v4.0 (https://github.com/techniboogie-dart/recase) to
+// include changes related to acronym preservation.
+@internal
+library worker_bee.recase;
+
+import 'package:meta/meta.dart';
+
+/// An instance of text to be re-cased.
+class _ReCase {
+  final String originalText;
+  final List<String> _words;
+
+  _ReCase(String text)
+      : originalText = text,
+        _words = text.groupIntoWords();
+
+  /// camelCase
+  String get camelCase => _getCamelCase();
+
+  /// CONSTANT_CASE
+  String get constantCase => _getConstantCase();
+
+  /// Sentence case
+  String get sentenceCase => _getSentenceCase();
+
+  /// snake_case
+  String get snakeCase => _getSnakeCase();
+
+  /// dot.case
+  String get dotCase => _getSnakeCase(separator: '.');
+
+  /// param-case
+  String get paramCase => _getSnakeCase(separator: '-');
+
+  /// path/case
+  String get pathCase => _getSnakeCase(separator: '/');
+
+  /// PascalCase
+  String get pascalCase => _getPascalCase();
+
+  /// Header-Case
+  String get headerCase => _getPascalCase(separator: '-');
+
+  /// Title Case
+  String get titleCase => _getPascalCase(separator: ' ');
+
+  String _getCamelCase({String separator = ''}) {
+    List<String> words = _words.map(_upperCaseFirstLetter).toList();
+    if (_words.isNotEmpty) {
+      words[0] = words[0].toLowerCase();
+    }
+
+    return words.join(separator);
+  }
+
+  String _getConstantCase({String separator = '_'}) {
+    List<String> words = _words.map((word) => word.toUpperCase()).toList();
+
+    return words.join(separator);
+  }
+
+  String _getPascalCase({String separator = ''}) {
+    List<String> words = _words.map(_upperCaseFirstLetter).toList();
+
+    return words.join(separator);
+  }
+
+  String _getSentenceCase({String separator = ' '}) {
+    List<String> words = _words.map((word) => word.toLowerCase()).toList();
+    if (_words.isNotEmpty) {
+      words[0] = _upperCaseFirstLetter(words[0]);
+    }
+
+    return words.join(separator);
+  }
+
+  String _getSnakeCase({String separator = '_'}) {
+    List<String> words = _words.map((word) => word.toLowerCase()).toList();
+
+    return words.join(separator);
+  }
+
+  String _upperCaseFirstLetter(String word) {
+    return '${word.substring(0, 1).toUpperCase()}${word.substring(1).toLowerCase()}';
+  }
+}
+
+/// Recasing string helpers.
+extension StringReCase on String {
+  /// The capitalized word.
+  String get capitalized {
+    if (length < 2) return toUpperCase();
+    return this[0].toUpperCase() + substring(1).toLowerCase();
+  }
+
+  /// camelCase
+  String get camelCase => _ReCase(this).camelCase;
+
+  /// CONSTANT_CASE
+  String get constantCase => _ReCase(this).constantCase;
+
+  /// Sentence case
+  String get sentenceCase => _ReCase(this).sentenceCase;
+
+  /// snake_case
+  String get snakeCase => _ReCase(this).snakeCase;
+
+  /// dot.case
+  String get dotCase => _ReCase(this).dotCase;
+
+  /// param-case
+  String get paramCase => _ReCase(this).paramCase;
+
+  /// path/case
+  String get pathCase => _ReCase(this).pathCase;
+
+  /// PascalCase
+  String get pascalCase => _ReCase(this).pascalCase;
+
+  /// Header-Case
+  String get headerCase => _ReCase(this).headerCase;
+
+  /// Title Case
+  String get titleCase => _ReCase(this).titleCase;
+
+  // "acm-success"-> "acm success"
+  static final _nonAlphaNumericChars = RegExp(r'[^A-Za-z0-9+]');
+
+  // TESTv4 -> "TEST v4"
+  static final _standaloneVLower = RegExp(r'([^a-z]{2,})v([0-9]+)');
+
+  // TestV4 -> "Test V4"
+  static final _standaloneVUpper = RegExp(r'([^A-Z]{2,})V([0-9]+)');
+
+  // "AcmSuccess" -> "Acm Success"
+  static final _camelCasedWords =
+      RegExp(r'(?<=[a-z])(?=[A-Z]([a-zA-Z]|[0-9]))');
+
+  // "ACMSuccess" -> "ACM Success"
+  static final _acronyms = RegExp(r'([A-Z]+)([A-Z][a-z])');
+
+  // "s3ec2" -> "s3 ec2"
+  static final _numInMiddleOrEnd = RegExp(r'([0-9])([a-zA-Z])');
+
+  /// Splits `this` into words along word boundaries.
+  List<String> groupIntoWords() {
+    var result = this;
+
+    // all non-alphanumeric characters: "acm-success"-> "acm success"
+    result = result.replaceAll(_nonAlphaNumericChars, ' ');
+
+    // if a number has a standalone v in front of it, separate it out
+    result = result
+        // TESTv4 -> "TEST v4"
+        .replaceAllMapped(
+            _standaloneVLower, (m) => '${m.group(1)} v${m.group(2)}')
+
+        // TestV4 -> "Test V4"
+        .replaceAllMapped(
+            _standaloneVUpper, (m) => '${m.group(1)} V${m.group(2)}');
+
+    // add a space between camelCased words: "AcmSuccess" -> "Acm Success"
+    result = result.split(_camelCasedWords).join(' ');
+
+    // add a space after acronyms: "ACMSuccess" -> "ACM Success"
+    result = result.replaceAllMapped(
+        _acronyms, (m) => '${m.group(1)} ${m.group(2)}');
+
+    // add space after a number in the middle of a word: "s3ec2" -> "s3 ec2"
+    result = result.replaceAllMapped(
+        _numInMiddleOrEnd, (m) => '${m.group(1)} ${m.group(2)}');
+
+    // remove extra spaces - multiple consecutive ones or those and the
+    // beginning/end of words
+    result = result.replaceAll(RegExp(r'\s+'), ' ').trim();
+
+    return result.split(' ');
+  }
+}

--- a/packages/worker_bee/lib/src/serializers/serializers.dart
+++ b/packages/worker_bee/lib/src/serializers/serializers.dart
@@ -2,6 +2,7 @@ import 'package:built_value/serializer.dart';
 import 'package:meta/meta.dart';
 import 'package:worker_bee/src/exception/worker_bee_exception.dart';
 import 'package:worker_bee/src/serializers/stack_trace_serializer.dart';
+import 'package:worker_bee/src/serializers/stream_serializer.dart';
 import 'package:worker_bee/worker_bee.dart';
 
 part 'serializers.g.dart';
@@ -13,5 +14,6 @@ part 'serializers.g.dart';
   LogMessage,
 ])
 final Serializers workerBeeSerializers = (_$workerBeeSerializers.toBuilder()
+      ..add(const StreamSerializer())
       ..add(const StackTraceSerializer()))
     .build();

--- a/packages/worker_bee/lib/src/serializers/stack_trace_serializer.dart
+++ b/packages/worker_bee/lib/src/serializers/stack_trace_serializer.dart
@@ -28,18 +28,22 @@ class StackTraceSerializer implements PrimitiveSerializer<StackTrace> {
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
+    StackTrace? stackTrace;
     if (serialized is StackTrace) {
-      return serialized;
+      stackTrace = serialized;
     }
     if (serialized is String) {
-      return Trace.parse(serialized);
+      stackTrace = Trace.parse(serialized);
     }
     if (serialized is List<String>) {
-      return Trace(serialized.map(Frame.parseFriendly));
+      stackTrace = Trace(serialized.map(Frame.parseFriendly));
     }
-    throw ArgumentError(
-      'Unknown StackFrame type (${serialized.runtimeType}): $serialized',
-    );
+    if (stackTrace == null) {
+      throw ArgumentError(
+        'Unknown StackFrame type (${serialized.runtimeType}): $serialized',
+      );
+    }
+    return stackTrace;
   }
 
   @override

--- a/packages/worker_bee/lib/src/serializers/stream_serializer_js.dart
+++ b/packages/worker_bee/lib/src/serializers/stream_serializer_js.dart
@@ -1,10 +1,15 @@
 import 'dart:async';
-import 'dart:html';
 
+import 'package:async/async.dart';
 import 'package:built_value/serializer.dart';
 import 'package:meta/meta.dart';
+import 'package:worker_bee/src/js/interop/common.dart';
+import 'package:worker_bee/src/js/interop/readable_stream.dart';
 import 'package:worker_bee/src/js/message_port_channel.dart';
 import 'package:worker_bee/src/serializers/stream_serializer.dart';
+
+/// A method which registers a pending operation with the worker.
+typedef AddPendingOperation = void Function(CancelableOperation<void>);
 
 /// {@template worker_bee.serializers.stream_serializer_impl_js}
 /// JS implementation of [StreamSerializer].
@@ -23,14 +28,57 @@ class StreamSerializerImpl extends StreamSerializer {
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    if (serialized is! MessagePort) {
-      throw ArgumentError(
-        'Cannot deserialize $serialized to Stream. Must be a MessagePort.',
-      );
+    final addPendingOperation =
+        Zone.current[#addPendingOperation] as AddPendingOperation?;
+
+    // When the stream receives a listener, only then track its progress via
+    // a `CancelableOperation`. To do this, wrap the stream in a separate
+    // controller so that we have full control over the subscription lifecycle
+    // events which will be overriden by the user-supplied ones on the
+    // subcription returned from this method.
+    StreamSubscription<Object?> onListen(
+      Stream<Object?> stream,
+      // ignore: avoid_positional_boolean_parameters
+      bool cancelOnError,
+    ) {
+      final controller = StreamController<Object?>(sync: true);
+      controller.onListen = () {
+        late CancelableCompleter<void> completer;
+        final subscription = stream.listen(
+          controller.add,
+          onError: (Object error, StackTrace stackTrace) {
+            controller.addError(error, stackTrace);
+            completer.completeError(error, stackTrace);
+          },
+          onDone: () {
+            controller.close();
+            completer.complete();
+          },
+          cancelOnError: cancelOnError,
+        );
+        completer = CancelableCompleter(onCancel: subscription.cancel);
+        addPendingOperation?.call(completer.operation);
+
+        controller
+          ..onPause = subscription.pause
+          ..onResume = subscription.resume
+          ..onCancel = subscription.cancel;
+      };
+      return controller.stream.listen(null);
     }
-    return serialized.onMessage.map((event) {
-      return serializers.deserialize(event.data);
-    });
+
+    if (supportsTransferableStreams) {
+      serialized as ReadableStream<Object?>;
+      return serialized.stream
+          .map(serializers.deserialize)
+          .transform(StreamTransformer(onListen));
+    }
+
+    serialized as MessagePort;
+    return MessagePortChannel<Object?>(
+      serialized,
+      serializers: serializers,
+    ).stream.transform(StreamTransformer(onListen));
   }
 
   @override
@@ -40,6 +88,12 @@ class StreamSerializerImpl extends StreamSerializer {
     FullType specifiedType = FullType.unspecified,
   }) {
     final transfer = Zone.current[#transfer] as List<Object>?;
+    if (supportsTransferableStreams) {
+      final readableStream =
+          object.map(serializers.serialize).asReadableStream();
+      transfer?.add(readableStream);
+      return readableStream;
+    }
     final messageChannel = MessageChannel();
     transfer?.add(messageChannel.port2);
     final workerBeeChannel = MessagePortChannel<Object?>(

--- a/packages/worker_bee/lib/worker_bee.dart
+++ b/packages/worker_bee/lib/worker_bee.dart
@@ -8,7 +8,7 @@ import 'package:built_value/serializer.dart';
 import 'package:worker_bee/src/common.dart';
 
 import 'src/preamble.dart';
-import 'src/vm/impl.dart' if (dart.library.html) 'src/js/impl.dart';
+import 'src/vm/impl.dart' if (dart.library.js) 'src/js/impl.dart';
 
 export 'package:async/async.dart';
 export 'package:logging/logging.dart';
@@ -18,7 +18,7 @@ export 'src/logger/log_message.dart';
 export 'src/pool/assignment_strategy.dart';
 export 'src/pool/worker_pool.dart';
 export 'src/preamble.dart' hide runTraced;
-export 'src/worker_bee_vm.dart' if (dart.library.html) 'src/worker_bee_js.dart';
+export 'src/worker_bee_vm.dart' if (dart.library.js) 'src/worker_bee_js.dart';
 
 /// {@template worker_bee.worker_bee}
 /// Annotation class for marking worker bees.

--- a/packages/worker_bee/pubspec.yaml
+++ b/packages/worker_bee/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/dnys1/worker_bee
 publish_to: https://pub.dillonnys.com
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   async: ^2.8.0

--- a/packages/worker_bee/test/readable_stream_test.dart
+++ b/packages/worker_bee/test/readable_stream_test.dart
@@ -1,0 +1,226 @@
+@TestOn('browser')
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:worker_bee/src/js/interop/readable_stream.dart';
+
+void main() {
+  ReadableStream<List<int>> createReadableStream() {
+    return ReadableStream(UnderlyingSource(
+      start: (controller) {
+        controller.enqueue(Uint8List.fromList([1, 2, 3, 4, 5]));
+        controller.enqueue(Uint8List.fromList([6, 7, 8, 9, 0]));
+        controller.close();
+      },
+    ));
+  }
+
+  group('ReadableStreamWrapper', () {
+    test('new', () {
+      final readableStream = createReadableStream();
+      expect(
+        readableStream.stream,
+        emitsInOrder(<Matcher>[
+          orderedEquals(<int>[1, 2, 3, 4, 5]),
+          orderedEquals(<int>[6, 7, 8, 9, 0]),
+          emitsDone,
+        ]),
+      );
+    });
+
+    test('progress', () {
+      final readableStream = createReadableStream();
+      expect(
+        readableStream.progress,
+        emitsInOrder(<Object>[
+          5,
+          10,
+          emitsDone,
+        ]),
+      );
+    });
+
+    group('asReadableStream (async)', () {
+      test('', () {
+        final Stream<List<int>> stream = Stream.fromIterable([
+          [1, 2, 3, 4, 5],
+          [6, 7, 8, 9, 0]
+        ]);
+        final ReadableStream readableStream = stream.asReadableStream();
+        expect(
+          readableStream.stream,
+          emitsInOrder(<Matcher>[
+            orderedEquals(<int>[1, 2, 3, 4, 5]),
+            orderedEquals(<int>[6, 7, 8, 9, 0]),
+            emitsDone,
+          ]),
+        );
+        expect(
+          readableStream.progress,
+          emitsInOrder(<Object>[
+            5,
+            10,
+            emitsDone,
+          ]),
+        );
+      });
+
+      test('onError (caught)', () async {
+        final StreamController<List<int>> controller = StreamController();
+        addTearDown(controller.close);
+
+        Object? error;
+        final ReadableStream readableStream =
+            controller.stream.asReadableStream(
+          onError: expectAsync2((e, st) {
+            error = e;
+          }),
+        );
+        controller.add([1, 2, 3, 4, 5]);
+        controller.addError('failure');
+        controller.add([6, 7, 8, 9, 0]);
+        expect(
+          readableStream.progress,
+          emitsInOrder(<Object>[
+            5,
+            emitsDone,
+          ]),
+        );
+        await expectLater(
+          readableStream.stream,
+          emitsInOrder(<Matcher>[
+            orderedEquals(<int>[1, 2, 3, 4, 5]),
+            emitsDone,
+          ]),
+        );
+        expect(error, 'failure');
+      });
+
+      test('onError (unhandled)', () {
+        final StreamController<List<int>> controller = StreamController();
+        addTearDown(controller.close);
+
+        final ReadableStream readableStream =
+            controller.stream.asReadableStream();
+        controller.add([1, 2, 3, 4, 5]);
+        controller.addError('failure');
+        controller.add([6, 7, 8, 9, 0]);
+        expect(
+          readableStream.stream,
+          emitsInOrder(<Matcher>[
+            orderedEquals(<int>[1, 2, 3, 4, 5]),
+            emitsError('failure'),
+            emitsDone,
+          ]),
+        );
+        expect(
+          readableStream.progress,
+          emitsInOrder(<Object>[
+            5,
+            emitsDone,
+          ]),
+        );
+      }, onPlatform: const <String, Object>{
+        'safari': Skip('TODO: Investigate WebKit failures')
+      });
+    });
+
+    group('asReadableStream (sync)', () {
+      test('', () {
+        final StreamController<List<int>> controller =
+            StreamController(sync: true);
+        final ReadableStream readableStream =
+            controller.stream.asReadableStream();
+        controller.add([1, 2, 3, 4, 5]);
+        controller.add([6, 7, 8, 9, 0]);
+        controller.close();
+        expect(
+          readableStream.stream,
+          emitsInOrder(<Matcher>[
+            orderedEquals(<int>[1, 2, 3, 4, 5]),
+            orderedEquals(<int>[6, 7, 8, 9, 0]),
+            emitsDone,
+          ]),
+        );
+        expect(
+          readableStream.progress,
+          emitsInOrder(<Object>[
+            5,
+            10,
+            emitsDone,
+          ]),
+        );
+      });
+
+      test('onError (caught)', () async {
+        final StreamController<List<int>> controller =
+            StreamController(sync: true);
+        addTearDown(controller.close);
+
+        Object? error;
+        final ReadableStream readableStream =
+            controller.stream.asReadableStream(
+          onError: expectAsync2((e, st) {
+            error = e;
+          }),
+        );
+        controller.add([1, 2, 3, 4, 5]);
+        controller.addError('failure');
+        controller.add([6, 7, 8, 9, 0]);
+        expect(
+          readableStream.progress,
+          emitsInOrder(<Object>[
+            5,
+            emitsDone,
+          ]),
+        );
+        await expectLater(
+          readableStream.stream,
+          emitsInOrder(<Matcher>[
+            orderedEquals(<int>[1, 2, 3, 4, 5]),
+            emitsDone,
+          ]),
+        );
+        expect(error, 'failure');
+      });
+
+      test('onError (unhandled)', () {
+        final StreamController<List<int>> controller =
+            StreamController(sync: true);
+        addTearDown(controller.close);
+
+        final ReadableStream readableStream =
+            controller.stream.asReadableStream();
+        controller.add([1, 2, 3, 4, 5]);
+        controller.addError('failure');
+        controller.add([6, 7, 8, 9, 0]);
+        expect(
+          readableStream.stream,
+          emitsInOrder(<Matcher>[
+            orderedEquals(<int>[1, 2, 3, 4, 5]),
+            emitsError('failure'),
+            emitsDone,
+          ]),
+        );
+        expect(
+          readableStream.progress,
+          emitsInOrder(<Object>[
+            5,
+            emitsDone,
+          ]),
+        );
+      }, onPlatform: const <String, Object>{
+        'safari': Skip('TODO: Investigate WebKit failures')
+      });
+    });
+
+    test('multiple streams can be expanded', () {
+      final stream1 = createReadableStream();
+      final stream2 = createReadableStream();
+
+      expect(stream1.stream, isNot(stream2.stream));
+    });
+  });
+}

--- a/packages/worker_bee/test/stream_serializer_test.dart
+++ b/packages/worker_bee/test/stream_serializer_test.dart
@@ -1,12 +1,8 @@
-@TestOn('browser')
-
 import 'dart:async';
 
 import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
-import 'package:worker_bee/src/js/interop/common.dart';
 import 'package:worker_bee/src/serializers/serializers.dart';
-import 'package:worker_bee/worker_bee.dart';
 
 import 'custom_type.dart';
 
@@ -14,7 +10,7 @@ void main() {
   final serializers =
       (workerBeeSerializers.toBuilder()..add(CustomType.serializer)).build();
 
-  void streamTest<T>(List<T> elements) {
+  void serializerTest<T>(List<T> elements) {
     final stream = Stream.fromIterable(elements);
     final serialized = serializers.serialize(
       stream,
@@ -28,60 +24,13 @@ void main() {
     expect(deserialized, emitsInOrder(elements));
   }
 
-  Future<void> streamPortTest<T extends Object>(List<T> elements) async {
-    final stream = Stream.fromIterable(elements);
-    final messageChannel = MessageChannel();
-    final transfer = <Object>[];
-    final serialized = runZoned(
-      () => serializers.serialize(
-        stream,
-        specifiedType: const FullType(Stream),
-      ),
-      zoneValues: {
-        #transfer: transfer,
-      },
-    );
-    messageChannel.port1.postMessage(serialized, transfer);
-
-    final List<CancelableOperation<void>> pendingOps = [];
-    final message = await messageChannel.port2.onMessage.first;
-    final deserialized = runZoned(
-      () => serializers.deserialize(
-        message.data,
-        specifiedType: const FullType(Stream),
-      ),
-      zoneValues: {
-        #addPendingOperation: pendingOps.add,
-      },
-    );
-    await expectLater(
-      deserialized,
-      allOf([
-        isA<Stream>(),
-        emitsInOrder(<Object>[...elements, emitsDone]),
-      ]),
-    );
-    expect(pendingOps, isNotEmpty);
-    expect(
-      Future.wait<void>(pendingOps.map((op) => op.valueOrCancellation())),
-      completes,
-    );
-  }
-
   group('StreamSerializer', () {
-    group('Stream<int>', () {
+    test('Stream<int>', () {
       const elements = [1, 2, 3, 4, 5];
-
-      test('', () {
-        streamTest(elements);
-      });
-
-      test('(channeled)', () {
-        streamPortTest(elements);
-      });
+      serializerTest(elements);
     });
 
-    group('Stream<CustomType>', () {
+    test('Stream<CustomType>', () {
       final elements = [
         CustomType((b) => b..customField = 'a'),
         CustomType((b) => b..customField = 'b'),
@@ -89,14 +38,7 @@ void main() {
         CustomType((b) => b..customField = 'd'),
         CustomType((b) => b..customField = 'e'),
       ];
-
-      test('', () {
-        streamTest(elements);
-      });
-
-      test('(channeled)', () {
-        streamPortTest(elements);
-      });
+      serializerTest(elements);
     });
   });
 }

--- a/packages/worker_bee/test/stream_serializer_test.dart
+++ b/packages/worker_bee/test/stream_serializer_test.dart
@@ -1,8 +1,10 @@
-@Skip('Re-enable when StreamSerializer is added back')
+import 'dart:async';
 
 import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
+import 'package:worker_bee/src/js/interop/common.dart';
 import 'package:worker_bee/src/serializers/serializers.dart';
+import 'package:worker_bee/worker_bee.dart';
 
 import 'custom_type.dart';
 
@@ -21,16 +23,63 @@ void main() {
       specifiedType: const FullType(Stream),
     );
     expect(deserialized, isA<Stream>());
-    expect((deserialized as Stream), emitsInOrder(elements));
+    expect(deserialized, emitsInOrder(elements));
+  }
+
+  Future<void> streamPortTest<T extends Object>(List<T> elements) async {
+    final stream = Stream.fromIterable(elements);
+    final messageChannel = MessageChannel();
+    final transfer = <Object>[];
+    final serialized = runZoned(
+      () => serializers.serialize(
+        stream,
+        specifiedType: const FullType(Stream),
+      ),
+      zoneValues: {
+        #transfer: transfer,
+      },
+    );
+    messageChannel.port1.postMessage(serialized, transfer);
+
+    final List<CancelableOperation<void>> pendingOps = [];
+    final message = await messageChannel.port2.onMessage.first;
+    final deserialized = runZoned(
+      () => serializers.deserialize(
+        message.data,
+        specifiedType: const FullType(Stream),
+      ),
+      zoneValues: {
+        #addPendingOperation: pendingOps.add,
+      },
+    );
+    await expectLater(
+      deserialized,
+      allOf([
+        isA<Stream>(),
+        emitsInOrder(<Object>[...elements, emitsDone]),
+      ]),
+    );
+    expect(pendingOps, isNotEmpty);
+    expect(
+      Future.wait<void>(pendingOps.map((op) => op.valueOrCancellation())),
+      completes,
+    );
   }
 
   group('StreamSerializer', () {
-    test('Stream<int>', () {
+    group('Stream<int>', () {
       const elements = [1, 2, 3, 4, 5];
-      streamTest(elements);
+
+      test('', () {
+        streamTest(elements);
+      });
+
+      test('(channeled)', () {
+        streamPortTest(elements);
+      });
     });
 
-    test('Stream<CustomType>', () {
+    group('Stream<CustomType>', () {
       final elements = [
         CustomType((b) => b..customField = 'a'),
         CustomType((b) => b..customField = 'b'),
@@ -38,7 +87,14 @@ void main() {
         CustomType((b) => b..customField = 'd'),
         CustomType((b) => b..customField = 'e'),
       ];
-      streamTest(elements);
+
+      test('', () {
+        streamTest(elements);
+      });
+
+      test('(channeled)', () {
+        streamPortTest(elements);
+      });
     });
   });
 }

--- a/packages/worker_bee/test/stream_serializer_test.dart
+++ b/packages/worker_bee/test/stream_serializer_test.dart
@@ -1,3 +1,5 @@
+@TestOn('browser')
+
 import 'dart:async';
 
 import 'package:built_value/serializer.dart';

--- a/packages/worker_bee/test/transferable_test.dart
+++ b/packages/worker_bee/test/transferable_test.dart
@@ -1,0 +1,74 @@
+@TestOn('browser')
+
+import 'dart:async';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+import 'package:worker_bee/src/js/interop/common.dart';
+import 'package:worker_bee/src/serializers/serializers.dart';
+import 'package:worker_bee/worker_bee.dart';
+
+import 'custom_type.dart';
+
+void main() {
+  final serializers =
+      (workerBeeSerializers.toBuilder()..add(CustomType.serializer)).build();
+
+  Future<void> transferableTest<T extends Object>(List<T> elements) async {
+    final stream = Stream.fromIterable(elements);
+    final messageChannel = MessageChannel();
+    final transfer = <Object>[];
+    final serialized = runZoned(
+      () => serializers.serialize(
+        stream,
+        specifiedType: const FullType(Stream),
+      ),
+      zoneValues: {
+        #transfer: transfer,
+      },
+    );
+    messageChannel.port1.postMessage(serialized, transfer);
+
+    final List<CancelableOperation<void>> pendingOps = [];
+    final message = await messageChannel.port2.onMessage.first;
+    final deserialized = runZoned(
+      () => serializers.deserialize(
+        message.data,
+        specifiedType: const FullType(Stream),
+      ),
+      zoneValues: {
+        #addPendingOperation: pendingOps.add,
+      },
+    );
+    await expectLater(
+      deserialized,
+      allOf([
+        isA<Stream>(),
+        emitsInOrder(<Object>[...elements, emitsDone]),
+      ]),
+    );
+    expect(pendingOps, isNotEmpty);
+    expect(
+      Future.wait<void>(pendingOps.map((op) => op.valueOrCancellation())),
+      completes,
+    );
+  }
+
+  group('Transferable', () {
+    test('Stream<int>', () {
+      const elements = [1, 2, 3, 4, 5];
+      transferableTest(elements);
+    });
+
+    test('Stream<CustomType>', () {
+      final elements = [
+        CustomType((b) => b..customField = 'a'),
+        CustomType((b) => b..customField = 'b'),
+        CustomType((b) => b..customField = 'c'),
+        CustomType((b) => b..customField = 'd'),
+        CustomType((b) => b..customField = 'e'),
+      ];
+      transferableTest(elements);
+    });
+  });
+}

--- a/packages/worker_bee_builder/lib/src/impl/vm.dart
+++ b/packages/worker_bee_builder/lib/src/impl/vm.dart
@@ -42,7 +42,7 @@ ${trueResponseType.isVoid ? '' : 'final result ='} await worker.run(
   channel.sink.cast(),
 );
 // ignore: invalid_use_of_protected_member
-worker.logger.info('Finished');
+worker.logger.finest('Finished');
 ${allocate(DartTypes.async.unawaited)}(worker.close());
 ${allocate(DartTypes.isolate.isolate)}.exit(ports.donePort${trueResponseType.isVoid ? '' : ', result'});
             '''),


### PR DESCRIPTION
- Adds stream serialization support via `MessagePort` and `ReadableStream`, as available.
- Uses static interop for all JS APIs now